### PR TITLE
Don't include empty redirect URI or scope in parameters

### DIFF
--- a/src/o2.cpp
+++ b/src/o2.cpp
@@ -223,8 +223,10 @@ void O2::link() {
         parameters.append(qMakePair(QString(O2_OAUTH2_RESPONSE_TYPE),
                                     (grantFlow_ == GrantFlowAuthorizationCode)? QString(O2_OAUTH2_GRANT_TYPE_CODE): QString(O2_OAUTH2_GRANT_TYPE_TOKEN)));
         parameters.append(qMakePair(QString(O2_OAUTH2_CLIENT_ID), clientId_));
-        parameters.append(qMakePair(QString(O2_OAUTH2_REDIRECT_URI), redirectUri_));
-        parameters.append(qMakePair(QString(O2_OAUTH2_SCOPE), scope_.replace( " ", "+" )));
+        if ( !redirectUri_.isEmpty() )
+            parameters.append(qMakePair(QString(O2_OAUTH2_REDIRECT_URI), redirectUri_));
+        if ( !scope_.isEmpty() )
+            parameters.append(qMakePair(QString(O2_OAUTH2_SCOPE), scope_.replace( " ", "+" )));
         parameters.append(qMakePair(QString(O2_OAUTH2_STATE), uniqueState));
         if ( !apiKey_.isEmpty() )
             parameters.append(qMakePair(QString(O2_OAUTH2_API_KEY), apiKey_));


### PR DESCRIPTION
@m-kuhn here's the last useful looking patch which is stalled upstream -- see https://github.com/pipacs/o2/issues/158 for details