### PR TITLE
Fix for qOverload and git ignore a bunch of intermediates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,5 @@ o2.pro.user
 Makefile
 *.o
 moc_*
-libo2.so*
+# Include linux and Mac libs
+libo2.*

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,10 @@
 _build/
 *.DS_Store
 o2.pro.user
+
+# Intermediates
+.qmake.stash
+Makefile
+*.o
+moc_*
+libo2.so*

--- a/o2.pro
+++ b/o2.pro
@@ -9,7 +9,7 @@ TEMPLATE = lib
 DEFINES += O2_SHARED_LIB
 DEFINES += O2_DLL_EXPORT
 
-CONFIG += c++11
+CONFIG += c++14
 
 # The following define makes your compiler emit warnings if you use
 # any Qt feature that has been marked deprecated (the exact warnings


### PR DESCRIPTION
1. Change compiler req to c++14 because thats what qOverload needs
2. Add a bunch of intermediate files into the .gitignore