### PR TITLE
Remove cmake 4 incompliant lines

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -185,11 +185,6 @@ if(o2_WITH_KEYCHAIN)
 
 endif(o2_WITH_KEYCHAIN)
 
-if(BUILD_SHARED_LIBS AND APPLE AND POLICY CMP0042) # in CMake >= 2.8.12
-    cmake_policy(SET CMP0042 OLD)
-    set(CMAKE_MACOSX_RPATH OFF) # don't embed @rpath in install name
-endif(BUILD_SHARED_LIBS AND APPLE AND POLICY CMP0042)
-
 add_library( o2 ${o2_SRCS} ${o2_HDRS} )
 
 if(BUILD_SHARED_LIBS)


### PR DESCRIPTION
CMP0042 no longer exists on cmake 4 and I am not sure why exactly we are doing that.