### PR TITLE
Update local port if started with local port = 0 and successfull list…

### DIFF
--- a/src/o1.cpp
+++ b/src/o1.cpp
@@ -247,8 +247,11 @@ void O1::link() {
 
     if (!useExternalWebInterceptor_) {
         // Start reply server
-        if (!replyServer()->isListening())
-            replyServer()->listen(QHostAddress::Any, localPort());
+        if (!replyServer()->isListening()) {
+            if (replyServer()->listen(QHostAddress::Any, localPort()) && localPort() == 0) {
+                setLocalPort(replyServer()->serverPort());
+            }
+        }
     }
 
     // Get any query parameters for the request

--- a/src/o2.cpp
+++ b/src/o2.cpp
@@ -200,6 +200,9 @@ void O2::link() {
             // Start listening to authentication replies
             if (!replyServer()->isListening()) {
                 if (replyServer()->listen(QHostAddress::Any, localPort_)) {
+                    if (localPort() == 0) {
+                        setLocalPort(replyServer()->serverPort());
+                    }
                     log( QStringLiteral( "O2::link: Reply server listening on port %1" ).arg( localPort() ) );
                 } else {
                     log( QStringLiteral("O2::link: Reply server failed to start listening on port %1").arg( localPort() ), O0BaseAuth::LogLevel::Warning );


### PR DESCRIPTION
When starting O2 with setLocalPort(0) it will use a random free TCP port but never return the value.
With this change it will update the local port on successfully starting to listen on random port
This allows retrieving the new port in the parent application